### PR TITLE
Nonstandard gtest location

### DIFF
--- a/cmake/flann_utils.cmake
+++ b/cmake/flann_utils.cmake
@@ -56,7 +56,7 @@ macro(flann_add_gtest exe)
                     DEPENDS ${exe}
                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
                     VERBATIM
-                    COMMENT "Runnint gtest test(s) ${exe}")
+                    COMMENT "Running gtest test(s) ${exe}")
     # add dependency to 'test' target
     add_dependencies(flann_gtest test_${_testname})
 endmacro(flann_add_gtest)
@@ -76,7 +76,7 @@ macro(flann_add_cuda_gtest exe)
                     DEPENDS ${exe}
                     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
                     VERBATIM
-                    COMMENT "Runnint gtest test(s) ${exe}")
+                    COMMENT "Running gtest test(s) ${exe}")
     # add dependency to 'test' target
     add_dependencies(test test_${_testname})
 endmacro(flann_add_cuda_gtest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,6 +19,10 @@ if (PYTHON_EXECUTABLE)
     flann_download_test_data(brief100K.h5 e1e781c0955917bc2f0a27b6344c2342)
 endif()
 
+if (GTEST_FOUND)
+    include_directories(${GTEST_INCLUDE_DIRS})
+endif()
+
 if (GTEST_FOUND AND HDF5_FOUND)
     include_directories(${HDF5_INCLUDE_DIR})
 


### PR DESCRIPTION
If gtest is not installed to a system directory, flann is unable to compile the tests. This adds the gtest include directories to the include directory search path.

I've also tacked on a typo fix patch as well.
