### PR TITLE
Update index.py exception checking

### DIFF
--- a/src/python/pyflann/index.py
+++ b/src/python/pyflann/index.py
@@ -110,7 +110,7 @@ class FLANN(object):
             raise FLANNException('Cannot handle type: %s' % pts.dtype)
 
         if qpts.dtype.type not in allowed_types:
-            raise FLANNException('Cannot handle type: %s' % pts.dtype)
+            raise FLANNException('Cannot handle type: %s' % qpts.dtype)
 
         if pts.dtype != qpts.dtype:
             raise FLANNException('Data and query must have the same type')


### PR DESCRIPTION
In checking the type of the distribution of q, the exception message should call qpts.type instead of pts.dtype