### PR TITLE
Use string(JOIN) to avoid semicolons in pc file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.12)
 
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
@@ -148,6 +148,7 @@ endif(BUILD_CUDA_LIB)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(LZ4 REQUIRED liblz4)
+string(JOIN " " LZ4_STATIC_LDFLAGS_STR ${LZ4_STATIC_LDFLAGS})
 
 #set the C/C++ include path to the "include" directory
 include_directories(BEFORE ${PROJECT_SOURCE_DIR}/src/cpp)

--- a/cmake/flann.pc.in
+++ b/cmake/flann.pc.in
@@ -8,6 +8,6 @@ Name: @PROJECT_NAME@
 Description: @PKG_DESC@
 Version: @FLANN_VERSION@
 Requires: @PKG_EXTERNAL_DEPS@
-Libs: -L${libdir} @LZ4_STATIC_LDFLAGS@ -lflann -lflann_cpp
+Libs: -L${libdir} @LZ4_STATIC_LDFLAGS_STR@ -lflann -lflann_cpp
 Cflags: -I${includedir}
 


### PR DESCRIPTION
An issue was encountered (https://github.com/NixOS/nixpkgs/pull/129491) when updating the Nix package for FLANN, where a list-separating semicolon was making it into the pkgconfig file:

```
Name: flann
Description: Fast Library for Approximate Nearest Neighbors
Version: 1.9.1
Requires:
Libs: -L${libdir} -L/nix/store/3nf85zf44vyvwr32hx53v7swljxysyjm-lz4-1.9.3/lib;-llz4 -lflann -lflann_cpp
Cflags: -I${includedir}
```

This semicolon breaks the flag parsing logic in the linker and needs to be filtered out, either with a string replacement or by doing a string(JOIN) as in this PR, for which [CMake 3.12 is required](https://cmake.org/cmake/help/latest/command/string.html#join). Note that 3.12 was released in July 2018, so this change would break a user building `master` from source on Ubuntu 18.04, but is fine on 20.04 or anything newer than that.

This should go in after https://github.com/flann-lib/flann/issues/369; that change is being patched into Debian, Nix, Homebrew, buildroot, and probably elsewhere.

FYI @jspricke 